### PR TITLE
Change 200 OK return string to `good`

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ async function informAPI(url, name, token) {
   const result = await cloudflare.updateRecord(record, ip);
 
   // Only returns this response when no exception is thrown.
-  return new Response(`DNS Record Update Successful!`, {
+  return new Response(`good`, {
     status: 200,
     headers: {
       "Content-Type": "text/plain;charset=UTF-8",


### PR DESCRIPTION
inadyn parses the 200 return string for "good", "nochg", "dnserr", "911", "badauth", and "nohost". All other strings result in "NOTOK". This small change fixes this.

The UDM log before the change:
May 22 01:34:18 udm inadyn[10905]: Update forced for alias my.example.com, new IP# 1.2.3.4
May 22 01:34:18 udm inadyn[10905]: Fatal error in DDNS server response:
May 22 01:34:18 udm inadyn[10905]: [200 OK] DNS Record Update Successful!
May 22 01:34:18 udm inadyn[10905]: Error response from DDNS server, ignoring ...

After the change:
May 22 10:20:14 udm inadyn[18317]: Update forced for alias my.example.com, new IP# 1.2.3.4
May 22 10:20:14 udm inadyn[18317]: Updating cache for my.example.com
